### PR TITLE
Custom userflow events 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ## [v2.12.1]
-    Demote log level from error to warn
+
+- Demote log level from error to warn
+- Patched the history API methods, such as pushState and replaceState, to trigger a custom userflow:pushstate and userflow:replacestate events whenever the state changes, improving our handling of these changes.
 
 ## [v2.12.0]
 


### PR DESCRIPTION
As a work around for the issue with Tanstack router, I had updated our installation snippet to set a flag `window.__userflowPushStatePatch=true` and to override `pushState` and `replaceState`. Now, these methods emit custom events (`userflow:pushstate` or `userflow:replacestate`) before calling the original functions.

 The `observeWindowLocation` function will patch `pushState` and `replaceState` only if `window.__userflowPushStatePatch` is `false`. Otherwise, it calls `fireEventListener` whenever `userflow:pushstate` or `userflow:replacestate` is triggered.