### PR TITLE
no uncaught exception at init time because of failing load

### DIFF
--- a/src/userflow.ts
+++ b/src/userflow.ts
@@ -296,7 +296,7 @@ if (!userflow) {
   ) {
     userflow![method] = function () {
       var args = Array.prototype.slice.call(arguments)
-      userflow!.load()
+      userflow!.load().then(() => {}, () => {})
       q.push([method, null, args])
     } as any
   }
@@ -308,7 +308,7 @@ if (!userflow) {
   ) {
     userflow![method] = function () {
       var args = Array.prototype.slice.call(arguments)
-      userflow!.load()
+      userflow!.load().then(() => {}, () => {})
       var deferred: Deferred
       var promise = new Promise<void>(function (resolve, reject) {
         deferred = {resolve: resolve, reject: reject}


### PR DESCRIPTION
During its initialization cycle the package may trigger some unwanting "unhandled promise rejections" when attempting to call `stubVoid` and related.

It happens that while the code logs a warning in such case ([here](https://github.com/userflow/userflow.js/blob/main/src/userflow.ts#L277)), it also forwards the error within a rejected Promise ([here](https://github.com/userflow/userflow.js/blob/main/src/userflow.ts#L278)). Unfortunately this Promise is not caught in some code paths making it being considered as an uncaught exception.

The code [here](https://github.com/userflow/userflow.js/blob/main/src/userflow.ts#L299) should probably be adapted as follow:

```js
  var stubVoid = function (
    // eslint-disable-next-line es5/no-rest-parameters
    method: ConditionalKeys<Userflow, (...args: any[]) => void>
  ) {
    userflow![method] = function () {
      var args = Array.prototype.slice.call(arguments)
      userflow!.load().then(() => {}, () => {})
      q.push([method, null, args])
    } as any
  }
```

_I just added the `.then(() => {}, () => {})` which mostly catch the Promise if it fails_

And the code [here](https://github.com/userflow/userflow.js/blob/main/src/userflow.ts#L311):

```js
  var stubPromise = function (
    // eslint-disable-next-line es5/no-rest-parameters
    method: ConditionalKeys<Userflow, (...args: any[]) => Promise<void>>
  ) {
    userflow![method] = function () {
      var args = Array.prototype.slice.call(arguments)
      userflow!.load().then(() => {}, () => {})
      var deferred: Deferred
      var promise = new Promise<void>(function (resolve, reject) {
        deferred = {resolve: resolve, reject: reject}
      })
      q.push([method, deferred!, args])
      return promise
    } as any
  }
```

_I just added the `.then(() => {}, () => {})` which mostly catch the Promise if it fails_

Why the issue? Tools such as Datadog or Sentry reports such uncaught and it tends to make monitoring a bit blurry.

Fixes #19