### PR TITLE
fix: stub _getInitToken and _getIdentifiedUser for better typings

### DIFF
--- a/src/userflow.ts
+++ b/src/userflow.ts
@@ -129,6 +129,10 @@ export interface Userflow {
   setServerEndpoint(serverEndpoint: string | null | undefined): void
 
   disableEvalJs(): void
+
+  _getInitToken(): string | null
+
+  _getIdentifiedUser(): {externalId: string | null}
 }
 
 // Helper types for userflow.js API
@@ -376,6 +380,8 @@ if (!userflow) {
   // values and are not queued
   stubDefault('getResourceCenterState', null)
   stubDefault('isIdentified', false)
+  stubDefault('_getIdentifiedUser', null)
+  stubDefault('_getInitToken', null)
 }
 
 export default userflow!


### PR DESCRIPTION
The functions `_getInitiToken` and `_getIdentifiedUser` are added recently but they are are not exposed in types. You can still use them with `window.userflow`. This PR adds better types support for them.