### PR TITLE
feat: stub debugger function to toggle from sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,8 +113,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Deprecated `IdentifyParams` type was removed. Use `Attributes` instead.
 - Deprecated `immediate: boolean` option was removed - no longer relevant.
 
-[unreleased]: https://github.com/userflow/userflow.js/compare/v2.12.1...HEAD
-[v2.12.0]: https://github.com/userflow/userflow.js/compare/v2.12.0...v2.12.1
+[unreleased]: https://github.com/userflow/userflow.js/compare/v2.13.0...HEAD
+[v2.13.0]: https://github.com/userflow/userflow.js/compare/v2.12.1...v2.13.0
+[v2.12.1]: https://github.com/userflow/userflow.js/compare/v2.12.0...v2.12.1
 [v2.12.0]: https://github.com/userflow/userflow.js/compare/v2.11.0...v2.12.0
 [v2.11.0]: https://github.com/userflow/userflow.js/compare/v2.10.0...v2.11.0
 [v2.10.0]: https://github.com/userflow/userflow.js/compare/v2.9.0...v2.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v2.13.0]
+
+- Added `userflow.debugger()` to toggle the internal debugger for testing user flows.
+
 ## [v2.12.1]
 
 - Demote log level from error to warn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userflow.js",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "description": "Async loader for userflow.js",
   "homepage": "https://github.com/userflow/userflow.js",
   "repository": {

--- a/src/userflow.ts
+++ b/src/userflow.ts
@@ -129,6 +129,8 @@ export interface Userflow {
   setServerEndpoint(serverEndpoint: string | null | undefined): void
 
   disableEvalJs(): void
+
+  debugger(): Promise<void>
 }
 
 // Helper types for userflow.js API
@@ -371,6 +373,7 @@ if (!userflow) {
   stubPromise('track')
   stubPromise('updateGroup')
   stubPromise('updateUser')
+  stubPromise('debugger')
 
   // Methods that synchronously return and can be stubbed with default return
   // values and are not queued


### PR DESCRIPTION
With the introduction of debugger from `sdk`. We need to stub this method too. Or else, when users try to toggle debugger directly using the `userflow.debugger()` it will fail. As the method doesn't exist in the async loader and won't be stubbed or loaded.