### PR TITLE
fix: allow list to be passed as event attribute value

### DIFF
--- a/src/userflow.ts
+++ b/src/userflow.ts
@@ -164,11 +164,11 @@ export interface GroupOptions {
 }
 
 export interface EventAttributes {
-  [name: string]: AttributeLiteral | EventAttributeChange
+  [name: string]: AttributeLiteralOrList | EventAttributeChange
 }
 
 interface EventAttributeChange {
-  set?: AttributeLiteral
+  set?: AttributeLiteralOrList
   data_type?: AttributeDataType
 }
 


### PR DESCRIPTION
Fix the `EventAttribute` and `EventAttributeChange` definitions to accept `AttributeLiteralOrList` . To fix the typescript error when attempting to pass a list as an event attribute value.

We support following types as attribute values
https://github.com/userflow/userflow.js/blob/1b59fc766a4ce1657917037cf3df1e12d06e7576/src/userflow.ts#L141-L142

internal ticket: [DF-980](https://getbeamer.atlassian.net/browse/DF-980)